### PR TITLE
Fixed header links

### DIFF
--- a/js/template/header.js
+++ b/js/template/header.js
@@ -2,7 +2,7 @@ var header =  '        <div id="mainNav">'+
 '                          <nav class="navbar navbar-default">'+ 
  '                              <div class="container auto-center">'+ 
  '                                  <div class="navbar-header logoContainer text-center">'+ 
- '                                      <a href="index.html#page-top" class="page-scroll"><img class="logo logoDisplay auto-center" src="./images/logo-dark.png"></a>'+
+ '                                      <a href="#page-top" class="page-scroll"><img class="logo logoDisplay auto-center" src="./images/logo-dark.png"></a>'+
  '                                      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#menuPrimary">'+ 
  '                                           <i class="fa fa-bars"></i>'+ 
  '                                      </button>'+
@@ -10,19 +10,19 @@ var header =  '        <div id="mainNav">'+
  '                                  <div class="collapse navbar-collapse text-center" id="menuPrimary">'+ 
  '                                      <ul class="nav navbar-nav pull-right">'+ 
  '                                            <li class="nav-item hidden">'+ 
- '                                                <a class="page-scroll" href="index.html#page-top"> </a>'+ 
+ '                                                <a class="page-scroll" href="#page-top"> </a>'+ 
  '                                            </li>'+ 
  '                                            <li class="nav-item">'+ 
- '                                                <a class="page-scroll" href="index.html#intro" data-target="#menuPrimary">About</a>'+ 
+ '                                                <a class="page-scroll" href="#intro" data-target="#menuPrimary">About</a>'+ 
  '                                            </li>'+ 
  '	    	        			              <li class="nav-item">'+ 
  '                                                <a href="https://theletstream.com/techore/author/asetalias" data-target="#menuPrimary">Blog</a>'+ 
  '                                            </li>'+ 
  '                                            <li class="nav-item">'+ 
- '                                              <a class="page-scroll" href="index.html#events" data-target="#menuPrimary">Events</a>'+ 
+ '                                              <a class="page-scroll" href="#events" data-target="#menuPrimary">Events</a>'+ 
  '                                            </li>'+ 
  '	   		    	    	                  <li class="nav-item">    '+ 
- '    				        	        	    <a class="page-scroll" href="index.html#webinars" data-target="#menuPrimary">Webinars</a>'+ 
+ '    				        	        	    <a class="page-scroll" href="#webinars" data-target="#menuPrimary">Webinars</a>'+ 
  '                                            </li>'+ 
  '      			    		              <li class="nav-item">    '+ 
  '    	       			    	    	        <a href="gallery.htm" data-target="#menuPrimary">Photo Gallery</a>'+ 
@@ -31,10 +31,10 @@ var header =  '        <div id="mainNav">'+
  '                                            	<a href="communities.htm" data-target="#menuPrimary">Communities</a>'+ 
  '                                            </li>'+ 
  '                                            <li class="nav-item">    '+ 
- '                                              <a class="page-scroll" href="index.html#eventsParticipate" data-target="#menuPrimary">Participate</a>'+ 
+ '                                              <a class="page-scroll" href="#eventsParticipate" data-target="#menuPrimary">Participate</a>'+ 
  '                                            </li>'+ 
  '                                            <li class="nav-item">    '+ 
- '                                              <a class="page-scroll" href="index.html#team" data-target="#menuPrimary">Our Team</a>'+ 
+ '                                              <a class="page-scroll" href="#team" data-target="#menuPrimary">Our Team</a>'+ 
  '                                            </li>'+ 
  '                                      </ul>'+ 
  '                                 </div>'+ 


### PR DESCRIPTION
Issue:
-The links in the header referring to the fragments on the same page had 'index.html' written before the fragment id in their href attribute. This resulted in abrupt reloading of page instead of directly scrolling to the referred fragment.

Fix:
-Removed 'index.html' from href attribute of header links, leaving the fragment id intact.