### PR TITLE
Add Partial Rendering Folders to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/components/
+/home-sections/


### PR DESCRIPTION
- Add `/components/` and `/home-sections/` to gitignore to ignore partially rendered files from entering a commit.