### PR TITLE
Fixed content overflow of project cards in projects page on mobile screens

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -547,11 +547,10 @@ section .section-header{
 .eventBox,
 .youtubeBox,
 .projectBox{
-	height: 420px;
 	width: 340px;
 	max-width: 340px;	/** fix for Slick Slide CSS **/
 	margin:10px 20px;
-	padding:0px;
+	padding:0 0 8px 0;
 	background:#F2F1EF;
 	box-shadow:2px 2px 15px #979696;
 	box-sizing:border-box;
@@ -717,7 +716,7 @@ section .section-header{
 	.eventBox, .youtubeBox,
 	.projectBox{
 		width:250px;
-		margin:10px 2px;
+		margin:10px 5px;
 	}
 	.youtubeBox>div>div{
 		height:140px;
@@ -888,6 +887,14 @@ section .section-header{
     /*font: 900 6em 'Dosis', sans-serif;*/
     color: #fff;
     background: transparent;
+}
+
+#project-card-container{
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: stretch;
+	justify-content:center;
 }
 
 .projectBox .projectThumb .img-overlay{

--- a/showcase.html
+++ b/showcase.html
@@ -123,7 +123,7 @@
     </section>
     <section class="background-overlay" id="proj-section">
     <div class="container">
-        <div class="row row-centered">
+        <div class="row row-centered" id="project-card-container">
                     <div class="col-xs-3 projectBox col-centered text-center">
                         <div class="row projectThumb">
                             <img src="images/slides/slide1.jpg" />

--- a/templates/showcase.html
+++ b/templates/showcase.html
@@ -10,7 +10,7 @@
     </section>
     <section class="background-overlay" id="proj-section">
     <div class="container">
-        <div class="row row-centered">
+        <div class="row row-centered" id="project-card-container">
                 {%- for proj in projects %}
                     <div class="col-xs-3 projectBox col-centered text-center">
                         <div class="row projectThumb">


### PR DESCRIPTION
Resolves #90 .
 - Set height of project cards to `auto` for mobile viewports.

Preview link: https://aniverma17.github.io/asetalias.github.io/showcase.html .