### PR TITLE
Updates MarkupSafe requirement in requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ docopt==0.6.2
 easywatch==0.0.5
 Jinja2==2.10.3
 Markdown==3.0.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 pathtools==0.1.2
 PyYAML==5.2
 staticjinja==0.3.5


### PR DESCRIPTION
Followed the local setup instructions after cloning down forked repo: https://github.com/asetalias/asetalias.github.io/wiki/Building-the-Website

The step: pip install -r requirements.txt produced the error:
<img width="1169" alt="Screen Shot 2020-06-04 at 11 11 38 AM" src="https://user-images.githubusercontent.com/49009626/83795338-2cf5ee80-a654-11ea-842f-caf9f55a2c39.png">

Solution: Updated requirement MarkupSafe-1.1.1
pip freeze > requirements.tx